### PR TITLE
Bypass cache when updating flutter documentation

### DIFF
--- a/lib/plugins/dartdoc/plugin.dart
+++ b/lib/plugins/dartdoc/plugin.dart
@@ -73,7 +73,7 @@ class DartdocSearch extends BotPlugin {
     getEntries('flutter', bypassCache: true);
   }
 
-  static const expireDuration = Duration(minutes: 1);
+  static const expireDuration = Duration(hours: 1);
 
   @override
   String get name => 'DartdocSearch';

--- a/lib/plugins/dartdoc/plugin.dart
+++ b/lib/plugins/dartdoc/plugin.dart
@@ -66,14 +66,14 @@ class DartdocSearch extends BotPlugin {
     // Other packages are fetched and updated as needed.
     flutterCacheTimer = Timer.periodic(
       expireDuration * 0.9,
-      (_) => getEntries('flutter'),
+      (_) => getEntries('flutter', bypassCache: true),
     );
 
     // Kick off an initial load immediately
-    getEntries('flutter');
+    getEntries('flutter', bypassCache: true);
   }
 
-  static const expireDuration = Duration(hours: 1);
+  static const expireDuration = Duration(minutes: 1);
 
   @override
   String get name => 'DartdocSearch';
@@ -90,7 +90,10 @@ class DartdocSearch extends BotPlugin {
       '- `\$[name]`: Return the pub.dev page for the package `name`\n'
       '- `&[name]`: Search pub.dev for `name`\n';
 
-  Future<(String, List<DartdocEntry>)> getEntries(String package) async {
+  Future<(String, List<DartdocEntry>)> getEntries(
+    String package, {
+    bool bypassCache = false,
+  }) async {
     final cached = documentationCache[package];
     final now = DateTime.timestamp();
     final cacheExpiry = now.add(-expireDuration);
@@ -101,7 +104,7 @@ class DartdocSearch extends BotPlugin {
 
     final url = '${urlBase}index.json';
 
-    if (cached != null && cached.$1.isAfter(cacheExpiry)) {
+    if (!bypassCache && cached != null && cached.$1.isAfter(cacheExpiry)) {
       return (urlBase, cached.$2);
     }
 


### PR DESCRIPTION
Fixes a bug where the call to `getEntries` in the flutter eager update would just returned the cached flutter documentation, and not actually updating the entries as intended. This caused flutter documentation searches to seemingly randomly be slow.